### PR TITLE
BUG: conflict between deployment stages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test: .env
 
 # remove .tox and .env dirs
 clean:
-	rm -rf .env .tox
+	rm -rf .cache .env .tox
 
 # configure humilis
 configure:

--- a/humilis_elasticache/__init__.py
+++ b/humilis_elasticache/__init__.py
@@ -1,5 +1,5 @@
 """Humilis plug-in to deploy an Elasticache cluster."""
 
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 __author__ = "German Gomez-Herrero, FindHotel BV"

--- a/humilis_elasticache/resources.yaml.j2
+++ b/humilis_elasticache/resources.yaml.j2
@@ -13,8 +13,8 @@ resources:
     SubnetGroup:
         Type: "AWS::ElastiCache::SubnetGroup"
         Properties:
-            CacheSubnetGroupName: {{_layer.name}}
+            CacheSubnetGroupName: "{{_env.name}}-{{_layer.name}}-{{_env.stage}}"
             Description:
-                Elasticache ({{_env.name}}:{{_layer.name}}:{{_env.stage}})
+                "Elasticache ({{_env.name}}-{{_layer.name}}-{{_env.stage}})"
             SubnetIds:
                 {{subnet_ids}}


### PR DESCRIPTION
This PR fixes and issue that was causing parallel deployments (on different stages) to trying to create a cluster subnet group with exactly the same name, which led to a deployment error.