### PR TITLE
Create Redis clusters with several nodes and shards.

### DIFF
--- a/humilis_elasticache/meta.yaml.j2
+++ b/humilis_elasticache/meta.yaml.j2
@@ -34,7 +34,7 @@ meta:
             value:
                 no
 
-        rep_per_group:
+        replicas_per_group:
             description:
                 Numb replicas per node group when redis cluster mode enabled.
             value:

--- a/humilis_elasticache/meta.yaml.j2
+++ b/humilis_elasticache/meta.yaml.j2
@@ -28,6 +28,18 @@ meta:
             value:
                 1
 
+        redis_cluster_mode:
+            description:
+                Activate or not cluster mode for redis.
+            value:
+                no
+
+        rep_per_group:
+            description:
+                Numb replicas per node group when redis cluster mode enabled.
+            value:
+                1
+
         vpc_security_group_ids:
             description:
                 A list of VPC security group IDs

--- a/humilis_elasticache/outputs.yaml.j2
+++ b/humilis_elasticache/outputs.yaml.j2
@@ -11,10 +11,12 @@ outputs:
         Value:
             "Fn::GetAtt":
                 - CacheCluster
-                {% if engine=='memcached' %}
-                - ConfigurationEndpoint.Address
-                {% elif engine=='redis' %}
+                {% if engine=='memcached' or redis_cluster_mode %}
+                - ConfigurationEndPoint.Address
+                {% elif engine=='redis' and num_cache_nodes==1 %}
                 - RedisEndpoint.Address
+                {% elif engine=='redis' and num_cache_nodes > 1 %}
+                - PrimaryEndPoint.Address
                 {% endif %}
     CacheClusterPort:
         Description:
@@ -22,8 +24,10 @@ outputs:
         Value:
             "Fn::GetAtt":
                 - CacheCluster
-                {% if engine=='memcached' %}
-                - ConfigurationEndpoint.Port
-                {% elif engine=='redis' %}
+                {% if engine=='memcached' or redis_cluster_mode %}
+                - ConfigurationEndPoint.Port
+                {% elif engine=='redis' and num_cache_nodes==1 %}
                 - RedisEndpoint.Port
+                {% elif engine=='redis' and num_cache_nodes > 1 %}
+                - PrimaryEndPoint.Port
                 {% endif %}

--- a/humilis_elasticache/resources.yaml.j2
+++ b/humilis_elasticache/resources.yaml.j2
@@ -1,6 +1,23 @@
 ---
 resources:
     CacheCluster:
+    {% if engine == "redis" and num_cache_nodes > 1 %}
+        Type: "AWS::ElastiCache::ReplicationGroup"
+        Properties:
+            ReplicationGroupDescription:
+                "Deployed in Humilis env : {{_env.name}}-{{_env.stage}}"
+            CacheNodeType: {{cache_node_type}}
+            Engine: {{engine}}
+            {% if redis_cluster_mode %}
+            NumNodeGroups: {{num_cache_nodes}}
+            ReplicasPerNodeGroup: {{rep_per_group}}
+            {% elif not redis_cluster_mode %}
+            NumCacheClusters: {{num_cache_nodes}}
+            {% endif %}
+            SecurityGroupIds: {{vpc_security_group_ids}}
+            CacheSubnetGroupName:
+                Ref: SubnetGroup
+    {% else %}
         Type: "AWS::ElastiCache::CacheCluster"
         Properties:
             AZMode: {{az_mode}}
@@ -10,6 +27,7 @@ resources:
             VpcSecurityGroupIds: {{vpc_security_group_ids}}
             CacheSubnetGroupName:
                 Ref: SubnetGroup
+    {% endif %}
     SubnetGroup:
         Type: "AWS::ElastiCache::SubnetGroup"
         Properties:

--- a/humilis_elasticache/resources.yaml.j2
+++ b/humilis_elasticache/resources.yaml.j2
@@ -10,7 +10,7 @@ resources:
             Engine: {{engine}}
             {% if redis_cluster_mode %}
             NumNodeGroups: {{num_cache_nodes}}
-            ReplicasPerNodeGroup: {{rep_per_group}}
+            ReplicasPerNodeGroup: {{replicas_per_group}}
             {% elif not redis_cluster_mode %}
             NumCacheClusters: {{num_cache_nodes}}
             {% endif %}

--- a/tests/integration/humilis-elasticache.yaml
+++ b/tests/integration/humilis-elasticache.yaml
@@ -26,10 +26,49 @@ humilis-elasticache:
                     to_port: 6379
                     source_security_group_id: {"Ref": "HumilisElasticache"}
 
-        - layer: elasticache
+        - layer: elasticache1
           layer_type: elasticache
           description: Dummy layer to test the humilis-elasticache plugin
           engine: redis
+          num_cache_nodes: 1
+          subnet_ids:
+              - ref:
+                  parser: layer_output
+                  parameters:
+                      layer_name: vpc
+                      output_name: PublicSubnet1
+          vpc_security_group_ids:
+              - ref:
+                  parser: layer_output
+                  parameters:
+                      layer_name: security
+                      output_name: HumilisElasticache
+
+        - layer: elasticache2
+          layer_type: elasticache
+          description: Dummy layer to test the humilis-elasticache plugin
+          engine: redis
+          num_cache_nodes: 3
+          subnet_ids:
+              - ref:
+                  parser: layer_output
+                  parameters:
+                      layer_name: vpc
+                      output_name: PublicSubnet1
+          vpc_security_group_ids:
+              - ref:
+                  parser: layer_output
+                  parameters:
+                      layer_name: security
+                      output_name: HumilisElasticache
+
+        - layer: elasticache3
+          layer_type: elasticache
+          description: Dummy layer to test the humilis-elasticache plugin
+          engine: redis
+          redis_cluster_mode: yes
+          num_cache_nodes: 2
+          rep_per_group: 2
           subnet_ids:
               - ref:
                   parser: layer_output

--- a/tests/integration/humilis-elasticache.yaml
+++ b/tests/integration/humilis-elasticache.yaml
@@ -68,7 +68,7 @@ humilis-elasticache:
           engine: redis
           redis_cluster_mode: yes
           num_cache_nodes: 2
-          rep_per_group: 2
+          replicas_per_group: 2
           subnet_ids:
               - ref:
                   parser: layer_output


### PR DESCRIPTION
With this patch we can now create a redis cluster in the 3 modes available in AWS :
- Single node (no shards no replicas). This is the mode we already had.
- Several nodes (replicas) in only one shard (AWS call that "cluster mode disabled")
- Several nodes in several shards (AWS call that "cluster mode activated")